### PR TITLE
Improve torrent status display and API helpers

### DIFF
--- a/handlers/main_menu.py
+++ b/handlers/main_menu.py
@@ -37,15 +37,16 @@ async def handle_main_reply(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def handle_buttons(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
-    await query.answer()
     data = query.data
     if data.startswith('del_'):
+        await query.answer()
         from .torrent_ops import del_torrent
         hash_ = data[4:]
         await del_torrent(update, context, hash_)
     elif data.startswith('cat_'):
+        await query.answer()
         from .file_upload import handle_category_choice
         category = data[4:]
         await handle_category_choice(update, context, category)
     else:
-        await query.answer()
+        await query.answer("Unknown action")

--- a/handlers/notify.py
+++ b/handlers/notify.py
@@ -7,7 +7,6 @@ from utils import sanitize_torrent_name
 notified_torrents = load_notified_hashes()
 
 async def notify_finished(context):
-    global notified_torrents
     torrents = get_all_torrents()
     chat_id = config.NOTIFY_CHAT_ID
     for t in torrents:

--- a/handlers/torrent_ops.py
+++ b/handlers/torrent_ops.py
@@ -32,9 +32,10 @@ async def status_torrents(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not loading:
         await update.message.reply_text("No active downloads.", reply_markup=get_main_reply_keyboard())
         return
-    for idx, t in enumerate(loading, 1):
+    msg_lines = []
+    for t in loading:
         name = sanitize_torrent_name(t['name'])
-        msg_lines = [f"{name} ({t['progress']*100:.1f}% | {t['state']})" for t in loading]
+        msg_lines.append(f"{name} ({t['progress']*100:.1f}% | {t['state']})")
     await update.message.reply_text('\n'.join(msg_lines), reply_markup=get_main_reply_keyboard())
 
 async def del_torrent(update: Update, context: ContextTypes.DEFAULT_TYPE, hash_):

--- a/qbittorrent_api.py
+++ b/qbittorrent_api.py
@@ -2,12 +2,12 @@ import requests
 import config
 
 qbittorrent_cookies = None
+session = requests.Session()
 
 def qb_login():
     global qbittorrent_cookies
     url = f"{config.QBITTORRENT_URL}/api/v2/auth/login"
     data = {'username': config.QBITTORRENT_USERNAME, 'password': config.QBITTORRENT_PASSWORD}
-    session = requests.Session()
     response = session.post(url, data=data)
     if response.ok and response.text == 'Ok.':
         qbittorrent_cookies = session.cookies
@@ -18,7 +18,6 @@ def qb_api(path, method='get', data=None, files=None):
     if qbittorrent_cookies is None:
         qb_login()
     url = f"{config.QBITTORRENT_URL}/api/v2/{path}"
-    session = requests.Session()
     session.cookies = qbittorrent_cookies
     try:
         if method == 'get':

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,8 @@ import shutil
 import re
 import config
 
+_SANITIZE_RULES = None
+
 def clean_nfo_and_delete_folder(folder):
     if folder and os.path.isdir(folder):
         for nfo_file in glob.glob(os.path.join(folder, '**', '*.nfo'), recursive=True):
@@ -26,9 +28,14 @@ def load_sanitize_rules(filepath=config.SANITIZE_FILE):
                     rules.append(line)
     return rules
 
+def get_sanitize_rules():
+    global _SANITIZE_RULES
+    if _SANITIZE_RULES is None:
+        _SANITIZE_RULES = load_sanitize_rules()
+    return _SANITIZE_RULES
+
 def sanitize_torrent_name(name):
-    rules = load_sanitize_rules()
-    for pattern in rules:
+    for pattern in get_sanitize_rules():
         try:
             name = re.sub(pattern, ' ', name, flags=re.IGNORECASE)
         except re.error as e:


### PR DESCRIPTION
## Summary
- fix active download status list construction
- avoid duplicate callback answers in button handler
- cache sanitize rules and reuse qBittorrent session

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: numerous style violations across project)*

------
https://chatgpt.com/codex/tasks/task_e_6896933e551483319d6e916380907310